### PR TITLE
expand button already expands the code further

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.*
+yarn.lock
 .yarn/*
 !.yarn/patches
 !.yarn/plugins

--- a/components/docs/InstallationGuide.tsx
+++ b/components/docs/InstallationGuide.tsx
@@ -1,130 +1,149 @@
-"use client";
+'use client';
 
-import React, { useState } from "react";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { ChevronDown, ChevronUp, Copy, Check } from "lucide-react";
-import { Highlight, themes } from "prism-react-renderer";
+import React, { useState } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ChevronDown, ChevronUp, Copy, Check } from 'lucide-react';
+import { Highlight, themes } from 'prism-react-renderer';
 
 interface InstallationGuideProps {
-  componentName: string;
-  componentCode: string;
+	componentName: string;
+	componentCode: string;
 }
 
 export const InstallationGuide: React.FC<InstallationGuideProps> = ({
-  componentName,
-  componentCode,
+	componentName,
+	componentCode,
 }) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [copied, setCopied] = useState(false);
+	const [isExpanded, setIsExpanded] = useState(false);
+	const [copied, setCopied] = useState(false);
 
-  const formattedComponentName = componentName.trim().replace(/\s+/g, "");
+	const formattedComponentName = componentName.trim().replace(/\s+/g, '');
 
-  const toggleExpand = () => setIsExpanded(!isExpanded);
+	const toggleExpand = () => setIsExpanded(!isExpanded);
 
-  const copyToClipboard = async () => {
-    await navigator.clipboard.writeText(componentCode);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
+	const copyToClipboard = async () => {
+		await navigator.clipboard.writeText(componentCode);
+		setCopied(true);
+		setTimeout(() => setCopied(false), 2000);
+	};
 
-  const displayedCode = isExpanded
-    ? componentCode
-    : componentCode.split("\n").slice(0, 10).join("\n") + "\n...";
+	const displayedCode = isExpanded
+		? componentCode
+		: componentCode.split('\n').slice(0, 10).join('\n') + '\n...';
 
-  return (
-    <div className="space-y-4">
-      <Card>
-        <CardContent className="p-6">
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <Badge>1</Badge>
-              <p>Create the following file in your project:</p>
-            </div>
-            <pre className="overflow-x-auto rounded-lg bg-muted p-4">
-              <code>
-                components/{formattedComponentName}/{formattedComponentName}.tsx
-              </code>
-            </pre>
-          </div>
-        </CardContent>
-      </Card>
+	return (
+		<div className='space-y-4'>
+			<Card>
+				<CardContent className='p-6'>
+					<div className='space-y-4'>
+						<div className='flex items-center gap-2'>
+							<Badge>1</Badge>
+							<p>Create the following file in your project:</p>
+						</div>
+						<pre className='overflow-x-auto rounded-lg bg-muted p-4'>
+							<code>
+								components/{formattedComponentName}/
+								{formattedComponentName}.tsx
+							</code>
+						</pre>
+					</div>
+				</CardContent>
+			</Card>
 
-      <Card>
-        <CardContent className="p-6">
-          <div className="space-y-4">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Badge>2</Badge>
-                <p>Copy and paste the following code:</p>
-              </div>
-              <Button size="icon" variant="ghost" onClick={copyToClipboard}>
-                {copied ? (
-                  <Check className="h-4 w-4 text-green-500" />
-                ) : (
-                  <Copy className="h-4 w-4" />
-                )}
-              </Button>
-            </div>
-            <div className="relative">
-              <Highlight
-                theme={themes.dracula}
-                code={displayedCode}
-                language="tsx"
-              >
-                {({
-                  className,
-                  style,
-                  tokens,
-                  getLineProps,
-                  getTokenProps,
-                }) => (
-                  <pre
-                    className={`${className} text-sm h-64 overflow-y-auto rounded-lg border`}
-                    style={{
-                      ...style,
-                      padding: "16px",
-                      whiteSpace: "pre-wrap", // Enables word wrapping
-                      wordBreak: "break-word", // Breaks long words
-                    }}
-                  >
-                    {tokens.map((line, i) => (
-                      <div
-                        key={`line-${i}`}
-                        {...getLineProps({ line, key: i })}
-                      >
-                        {line.map((token, key) => (
-                          <span
-                            key={`token-${key}`}
-                            {...getTokenProps({ token, key })}
-                          />
-                        ))}
-                      </div>
-                    ))}
-                  </pre>
-                )}
-              </Highlight>
-              {!isExpanded && (
-                <div className="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-muted to-transparent" />
-              )}
-              <div className="absolute bottom-2 right-2">
-                <Button variant="outline" size="sm" onClick={toggleExpand}>
-                  {isExpanded ? (
-                    <>
-                      Collapse <ChevronUp className="ml-2 h-4 w-4" />
-                    </>
-                  ) : (
-                    <>
-                      Expand <ChevronDown className="ml-2 h-4 w-4" />
-                    </>
-                  )}
-                </Button>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-  );
+			<Card>
+				<CardContent className='p-6'>
+					<div className='space-y-4'>
+						<div className='flex items-center justify-between'>
+							<div className='flex items-center gap-2'>
+								<Badge>2</Badge>
+								<p>Copy and paste the following code:</p>
+							</div>
+							<Button
+								size='icon'
+								variant='ghost'
+								onClick={copyToClipboard}
+							>
+								{copied ? (
+									<Check className='h-4 w-4 text-green-500' />
+								) : (
+									<Copy className='h-4 w-4' />
+								)}
+							</Button>
+						</div>
+						<div className='relative'>
+							<Highlight
+								theme={themes.dracula}
+								code={displayedCode}
+								language='tsx'
+							>
+								{({
+									className,
+									style,
+									tokens,
+									getLineProps,
+									getTokenProps,
+								}) => (
+									<pre
+										className={`${className} ${
+											isExpanded && 'h-full'
+										} text-sm h-64 overflow-y-auto rounded-lg border`}
+										style={{
+											...style,
+											padding: '16px',
+											whiteSpace: 'pre-wrap', // Enables word wrapping
+											wordBreak: 'break-word', // Breaks long words
+										}}
+									>
+										{tokens.map((line, i) => (
+											<div
+												key={`line-${i}`}
+												{...getLineProps({
+													line,
+													key: i,
+												})}
+											>
+												{line.map((token, key) => (
+													<span
+														key={`token-${key}`}
+														{...getTokenProps({
+															token,
+															key,
+														})}
+													/>
+												))}
+											</div>
+										))}
+									</pre>
+								)}
+							</Highlight>
+							{!isExpanded && (
+								<div className='absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-muted to-transparent' />
+							)}
+							<div className='absolute bottom-2 right-2'>
+								<Button
+									variant='outline'
+									size='sm'
+									onClick={toggleExpand}
+								>
+									{isExpanded ? (
+										<>
+											Collapse{' '}
+											<ChevronUp className='ml-2 h-4 w-4' />
+										</>
+									) : (
+										<>
+											Expand{' '}
+											<ChevronDown className='ml-2 h-4 w-4' />
+										</>
+									)}
+								</Button>
+							</div>
+						</div>
+					</div>
+				</CardContent>
+			</Card>
+		</div>
+	);
 };


### PR DESCRIPTION
Hello! 👋
The expansion button of the InstallationGuide component has been improved. Now, when you click the expand button, the code area expands further, making it easier to view the content. This makes the “expand” functionality more useful and true to its purpose.
I thought this was a good idea because, as a user, having an expand button and clicking it, I want to see the entire content nicely expanded.

Unexpanded:
![imagen](https://github.com/user-attachments/assets/9edd0ae2-1e37-4717-864a-f0edac93d9eb)

Expanded:
![imagen](https://github.com/user-attachments/assets/1ace21bb-1ca4-42f2-aa53-0fe7e6b05a3a)


Changes made

1. The expand button now increases the visible code area even further in InstallationGuide.
2. The InstallationGuide component was also reformatted using the VS Code "Prettier" extension.
3. Added “yarn.lock” to .gitignore just for convenience and to avoid problems with “package-lock.json”.